### PR TITLE
feat: integrate IPNS endpoint for gasless publication

### DIFF
--- a/src/components/CreateNimi/CreateNimi.tsx
+++ b/src/components/CreateNimi/CreateNimi.tsx
@@ -38,15 +38,18 @@ import { setENSNameContentHash } from '../../hooks/useSetContentHash';
 import { useENSPublicResolverContract } from '../../hooks/useENSPublicResolverContract';
 import { PublishNimiModal } from './partials/PublishNimiModal';
 import { useLensDefaultProfileData } from '../../hooks/useLensDefaultProfileData';
-import { publishNimi } from './api';
+import { publishNimiViaIPNS } from './api';
+import { Web3Provider } from '@ethersproject/providers';
+import { namehash as ensNameHash, encodeContenthash } from '@ensdomains/ui';
 
 export interface CreateNimiProps {
   ensAddress: string;
   ensName: string;
   ensLabelName: string;
+  provider: Web3Provider;
 }
 
-export function CreateNimi({ ensAddress, ensName }: CreateNimiProps) {
+export function CreateNimi({ ensAddress, ensName, provider }: CreateNimiProps) {
   /**
    * @todo replace this API
    */
@@ -65,6 +68,7 @@ export function CreateNimi({ ensAddress, ensName }: CreateNimiProps) {
   const publicResolverContract = useENSPublicResolverContract();
   const [isPublishNimiModalOpen, setIsPublishNimiModalOpen] = useState(false);
   const [isPublishingNimi, setIsPublishingNimi] = useState(false);
+  const [isNimiPublished, setIsNimiPublished] = useState(false);
   const [publishNimiError, setPublishNimiError] = useState<Error>();
   const [publishNimiResponseIpfsHash, setPublishNimiResponseIpfsHash] = useState<string>();
   const [setContentHashTransaction, setSetContentHashTransaction] = useState<ContractTransaction>();
@@ -73,7 +77,10 @@ export function CreateNimi({ ensAddress, ensName }: CreateNimiProps) {
 
   // Form state manager
   const useFormContext = useForm<Nimi>({
-    resolver: yupResolver(nimiCard),
+    resolver: yupResolver(nimiCard, {
+      stripUnknown: true,
+      abortEarly: false,
+    }),
     defaultValues: {
       displayName: ensName,
       displayImageUrl: ensMetadata?.image,
@@ -127,6 +134,7 @@ export function CreateNimi({ ensAddress, ensName }: CreateNimiProps) {
       setIsPublishNimiModalOpen(true);
       setIsPublishingNimi(true);
       setPublishNimiError(undefined);
+      setIsNimiPublished(false);
     });
 
     try {
@@ -136,18 +144,38 @@ export function CreateNimi({ ensAddress, ensName }: CreateNimiProps) {
 
       publishNimiAbortController.current = new AbortController();
 
-      const { cid } = await publishNimi(data, publishNimiAbortController.current);
+      const signature = await provider.getSigner().signMessage(JSON.stringify(data));
 
-      if (!cid) {
-        throw new Error('No CID returned from publishNimi');
+      const { cidV1, ipns } = await publishNimiViaIPNS({
+        nimi: data,
+        signature,
+        controller: publishNimiAbortController.current,
+      });
+
+      if (!cidV1) {
+        throw new Error('No CID returned from publishNimiViaIPNS');
+      }
+
+      // Get current content hash from ENS contract
+      const currentContentHashEncoded = await publicResolverContract.contenthash(ensNameHash(ensName));
+      const contentHash = `ipns://${ipns}`;
+      const newContentHashEncoded = encodeContenthash(contentHash).encoded as unknown as string;
+
+      // User already uses the Nimi IPNS
+      if (newContentHashEncoded === currentContentHashEncoded) {
+        unstable_batchedUpdates(() => {
+          setIsNimiPublished(true);
+          setIsPublishingNimi(false);
+        });
+        return;
       }
 
       // Set the content
-      setPublishNimiResponseIpfsHash(cid);
+      setPublishNimiResponseIpfsHash(ipns);
       const setContentHashTransaction = await setENSNameContentHash({
         contract: publicResolverContract,
         name: data.ensName,
-        contentHash: `ipfs://${cid}`,
+        contentHash,
       });
 
       setSetContentHashTransaction(setContentHashTransaction);
@@ -156,6 +184,7 @@ export function CreateNimi({ ensAddress, ensName }: CreateNimiProps) {
 
       unstable_batchedUpdates(() => {
         setSetContentHashTransactionReceipt(setContentHashTransactionReceipt);
+        setIsNimiPublished(true);
         setIsPublishingNimi(false);
       });
     } catch (error) {
@@ -212,11 +241,10 @@ export function CreateNimi({ ensAddress, ensName }: CreateNimiProps) {
                     id="description"
                     {...register('description')}
                   ></TextArea>
-                  {/* <span  role="textbox" contenteditable  {...register('description')}></span> */}
                 </FormGroup>
 
                 {selectedLinkFieldList.map((link) => {
-                  const label = t(`formLabel.${link}`);
+                  const label = t(`formLabel.${link.toLowerCase()}`);
 
                   return (
                     <LinkFormGroup key={'blockchain-input-' + link}>
@@ -355,6 +383,7 @@ export function CreateNimi({ ensAddress, ensName }: CreateNimiProps) {
           ensName={ensName}
           ipfsHash={publishNimiResponseIpfsHash}
           isPublishing={isPublishingNimi}
+          isPublished={isNimiPublished}
           publishError={publishNimiError}
           setContentHashTransaction={setContentHashTransaction}
           setContentHashTransactionReceipt={setContentHashTransactionReceipt}

--- a/src/components/CreateNimi/api/index.ts
+++ b/src/components/CreateNimi/api/index.ts
@@ -43,3 +43,50 @@ export function publishNimi(payload: Nimi, controller?: AbortController): Promis
       };
     });
 }
+
+interface PublishNimiViaIPNSParams {
+  /**
+   * Nimi
+   */
+  nimi: Nimi;
+  /**
+   * EIP-712 signature
+   */
+  signature: string;
+  /**
+   * Abort controller
+   */
+  controller?: AbortController;
+}
+
+interface PublishNimiViaIPNSResponse {
+  cidV1: string;
+  ipns: string;
+}
+
+/**
+ *
+ * @param payload the payload from the form
+ * @param controller Abort controller
+ * @returns A promise with IPFS hash
+ */
+export function publishNimiViaIPNS({
+  nimi,
+  signature,
+  controller,
+}: PublishNimiViaIPNSParams): Promise<PublishNimiViaIPNSResponse> {
+  return axios
+    .post<{
+      data: PublishNimiViaIPNSResponse;
+    }>(
+      `${process.env.REACT_APP_NIMI_API_BASE_URL_V1_4}/nimi/publish/ipns`,
+      {
+        nimi,
+        signature,
+      },
+      {
+        signal: controller ? controller.signal : undefined,
+      }
+    )
+    .then(({ data }) => data.data);
+}

--- a/src/components/CreateNimi/partials/NimiLinkField/NimiLinkField.tsx
+++ b/src/components/CreateNimi/partials/NimiLinkField/NimiLinkField.tsx
@@ -65,6 +65,10 @@ export function NimiLinkField({ link, label }: NimiLinkFieldProps) {
   const hasAtField = [NimiLinkType.TWITTER, NimiLinkType.INSTAGRAM, NimiLinkType.TELEGRAM].includes(link);
 
   const onChange: ChangeEventHandler<HTMLInputElement> = (event) => {
+    console.log({
+      value: event.target.value,
+    });
+
     if (isValidUrl(event.target.value) && link === NimiLinkType.URL) {
       setIsError(true);
     } else {
@@ -78,12 +82,15 @@ export function NimiLinkField({ link, label }: NimiLinkFieldProps) {
     const newState: NimiLinkBaseDetails[] = hasLink
       ? prevState.map((curr) => {
           if (curr.type === link) {
-            return { ...curr, url: event.target.value };
+            return { ...curr, content: event.target.value };
           }
 
           return curr;
         })
       : [...prevState, { type: link, label, content: event.target.value }];
+    console.log({
+      newState,
+    });
     setValue('links', newState);
   };
 

--- a/src/components/CreateNimi/partials/NimiPreviewCard/NimiPreviewCard.tsx
+++ b/src/components/CreateNimi/partials/NimiPreviewCard/NimiPreviewCard.tsx
@@ -24,6 +24,8 @@ export function NimiPreviewCard({ nimi }: NimiPreviewCardProps) {
   const [previewNimi, setPreviewNimi] = useState<Nimi>();
 
   useEffect(() => {
+    // Filter invalid links
+
     nimiCard
       .validate(nimi, {
         abortEarly: false,

--- a/src/components/CreateNimi/partials/PublishNimiModal/PublishNimiModal.tsx
+++ b/src/components/CreateNimi/partials/PublishNimiModal/PublishNimiModal.tsx
@@ -45,6 +45,7 @@ const ModalFooter = styled(ModalFooterBase)`
 export interface PublishNimiModalProps {
   cancel: () => void;
   isPublishing: boolean;
+  isPublished: boolean;
   ensName: string;
   ipfsHash: string | undefined;
   publishError: Error | undefined;
@@ -63,11 +64,12 @@ export function PublishNimiModal({
   publishError,
   setContentHashTransaction,
   setContentHashTransactionReceipt,
+  isPublished,
 }: PublishNimiModalProps) {
   const { t } = useTranslation(['common', 'nimi']);
 
   const modalContent = () => {
-    if (setContentHashTransactionReceipt) {
+    if (setContentHashTransactionReceipt || isPublished) {
       return (
         <>
           <p>
@@ -126,7 +128,9 @@ export function PublishNimiModal({
       </ModalHeader>
       <ModalContent>{modalContent()}</ModalContent>
       <ModalFooter>
-        {(setContentHashTransactionReceipt || publishError) && <Button onClick={cancel}>{t('close')}</Button>}
+        {(setContentHashTransactionReceipt || publishError || isPublished) && (
+          <Button onClick={cancel}>{t('close')}</Button>
+        )}
       </ModalFooter>
     </Modal>
   );

--- a/src/pages/CreateNimiPage/CreateNimiPage.tsx
+++ b/src/pages/CreateNimiPage/CreateNimiPage.tsx
@@ -8,7 +8,7 @@ import { Container } from '../../components/Container';
 import { useWeb3React } from '@web3-react/core';
 
 export function CreateNimiPage() {
-  const { account } = useWeb3React();
+  const { account, provider } = useWeb3React();
   const { ensName } = useParams();
   const nodeHash = ensNameHash(ensName as string);
 
@@ -29,12 +29,17 @@ export function CreateNimiPage() {
     return <div>{error?.message}</div>;
   }
 
+  if (!provider) {
+    return <div>No web3 provider available</div>;
+  }
+
   return (
     <Container>
       <CreateNimi
         ensAddress={account as string}
         ensName={data.domain.name as string}
         ensLabelName={data.domain.labelName as string}
+        provider={provider}
       />
     </Container>
   );


### PR DESCRIPTION
# Summary

Uses `https://api.nimi.dev/v1.4/nimi/publish/ipns` to update Nimi's via IPNS records. This implementation allows for gasless updates. Users have to do a single transaction to the ENS resolver contract. After that, they can update their Nimi's without on-chain transactions.

When the user is ready to publish/update their Nimi, they sign a message with their wallet

<img width="945" alt="image" src="https://user-images.githubusercontent.com/1926216/184451595-e8feae66-8b16-468c-a0a6-838b17a68efb.png">

The signature is verified on the API side to prove ownership of the Nimi record, then the IPNS record is updated.

<img width="863" alt="image" src="https://user-images.githubusercontent.com/1926216/184451716-579bc8c0-b2f2-433a-b0d1-105cff6ac0cd.png">


