### PR TITLE
feat: fetch controlled ENS Names

### DIFF
--- a/src/graphql/ens/queries.ts
+++ b/src/graphql/ens/queries.ts
@@ -20,17 +20,31 @@ export const GET_SUBDOMAINS_SUBGRAPH = gql`
 `;
 
 export const GET_DOMAINS_SUBGRAPH = gql`
-  query getDomains($address: ID!, $first: Int, $skip: Int, $orderBy: Domain_orderBy) {
-    account(id: $address) {
-      domains(first: $first, skip: $skip, orderBy: $orderBy) {
+  query getDomainsOwnedOrControlledBy(
+    $addressID: ID!
+    $addressString: String!
+    $first: Int
+    $skip: Int
+    $orderBy: Domain_orderBy
+  ) {
+    account(id: $addressID) {
+      domainsOwned: domains(first: $first, skip: $skip, orderBy: $orderBy) {
         id
         labelName
         labelhash
         name
-        isMigrated
         parent {
           name
         }
+      }
+    }
+    domainsControlled: domains(first: $first, skip: $skip, orderBy: $orderBy, where: { owner: $addressString }) {
+      id
+      labelName
+      labelhash
+      name
+      owner {
+        id
       }
     }
   }

--- a/src/hooks/useGetENSDomainsByAddress.ts
+++ b/src/hooks/useGetENSDomainsByAddress.ts
@@ -1,0 +1,88 @@
+import { useEffect, useState } from 'react';
+import { GetDomainsOwnedOrControlledByQuery, useGetDomainsOwnedOrControlledByQuery } from '../generated/graphql/ens';
+
+export interface UserENSDomains {
+  data: GetDomainsOwnedOrControlledByQuery['domainsControlled'] | undefined;
+  loading: boolean;
+}
+
+/**
+ * Fetches all **valid** ENS domains owned or controlled by the given address.
+ *
+ * Names that include `[` or `]` are considered invalid unless they resolve to a valid ENS name.
+ *
+ * For example, `[b009fb4ac7328256e8cebb99127b1eb7e7ae60933e24f36f5567ef75724d690d].sismo.eth` should resolve to `abc.sismo.eth` to be considered valid.
+ *
+ * @param address
+ * @returns {UserENSDomains} data and loading state
+ */
+export function useGetENSDomainsByAddress(address: string): UserENSDomains {
+  const [domainList, setDomainList] = useState<GetDomainsOwnedOrControlledByQuery['domainsControlled'] | undefined>(
+    undefined
+  );
+
+  const query = useGetDomainsOwnedOrControlledByQuery({
+    variables: {
+      // GrahpQL cannot cast ID to String, hence why we need addressID and addressString
+      addressID: address.toLowerCase(),
+      addressString: address.toLowerCase(),
+    },
+  });
+
+  useEffect(() => {
+    if (!query.data) {
+      return;
+    }
+
+    const domainsOwned = query.data?.account?.domainsOwned ?? [];
+    const domainsControlled = query.data?.domainsControlled ?? [];
+    // We need to merge the two arrays and remove duplicates
+    const allUserDomains = [...domainsOwned, ...domainsControlled];
+
+    const uniqueDomains = allUserDomains.reduce((acc, domain) => {
+      // If the domain is already in the array, we don't want to add it again
+      const isDomainDuplicate = acc.find((d) => d?.id === domain?.id);
+      if (isDomainDuplicate) return acc;
+
+      const isNameEncrypted = domain?.name?.includes('[');
+
+      if (isNameEncrypted) {
+        // If the name is encrypted, we need to decrypt it
+        // The following helps finding subdomains that are encrypted at <name>.sismo.eth
+        const foundDomainFromAllUserDomains = allUserDomains.find(
+          ({ labelhash }) => labelhash?.toLowerCase() == domain.labelhash?.toLowerCase()
+        );
+
+        // Luckily, we can find the domain in the array, so we can use it to get the labelName
+        if (
+          foundDomainFromAllUserDomains &&
+          foundDomainFromAllUserDomains.labelName !== null &&
+          foundDomainFromAllUserDomains.labelName !== undefined
+        ) {
+          // Breakdown the domain into: subdomain, domain, tld (eth/xyz/etc)
+          const domainNameParts = domain?.name?.split('.') as string[];
+          // Repllce the subdomain with the decrypted name
+          domainNameParts[0] = foundDomainFromAllUserDomains.labelName;
+
+          domain = {
+            ...domain,
+            name: domainNameParts.join('.'),
+          };
+        }
+      }
+
+      if (!domain.name?.includes('[')) {
+        acc.push(domain as any);
+      }
+
+      return acc;
+    }, [] as GetDomainsOwnedOrControlledByQuery['domainsControlled']);
+
+    setDomainList(uniqueDomains);
+  }, [query.loading, query.data]);
+
+  return {
+    data: domainList,
+    loading: query.loading,
+  };
+}

--- a/src/modules/nimi-connect/containers/NimiConnectContainer/NimiConnectContainer.tsx
+++ b/src/modules/nimi-connect/containers/NimiConnectContainer/NimiConnectContainer.tsx
@@ -3,7 +3,6 @@ import { useState, useCallback } from 'react';
 import Select from 'react-select';
 import * as QRCode from 'qrcode';
 
-import { useGetDomainsQuery } from '../../../../generated/graphql/ens';
 import { Container } from '../../../../components/Container';
 import { Loader } from '../../../../components/Loader';
 import { Button } from '../../../../components/Button';
@@ -13,6 +12,7 @@ import { Card as CardBase, CardBody, CardTitle } from '../../../../components/Ca
 import styled from 'styled-components';
 import { FormGroup as FormGroupBase } from '../../../../components/form';
 import { unstable_batchedUpdates } from 'react-dom';
+import { useGetENSDomainsByAddress } from '../../../../hooks/useGetENSDomainsByAddress';
 
 const Card = styled(CardBase)`
   min-height: 300px;
@@ -51,12 +51,8 @@ export function NimiConnectContainer({ address }: NimiConnectContainerProps) {
   const [tokenQRDataURI, setTokenQRDataURI] = useState('');
   const [nimiToken, setNimiToken] = useState<CreateNimiConnectSessionResponse>();
   const [ensName, setEnsName] = useState<string>();
-  const { data, loading } = useGetDomainsQuery({
-    variables: {
-      address: address.toLowerCase(),
-    },
-  });
-  const ensNames = data?.account?.domains || [];
+  const { data, loading } = useGetENSDomainsByAddress(address);
+  const ensNames = data;
 
   const getNimiToken = useCallback(async () => {
     if (!account || !provider) {
@@ -100,10 +96,12 @@ export function NimiConnectContainer({ address }: NimiConnectContainerProps) {
     return <Loader />;
   }
 
-  if (ensNames.length === 0) {
-    <Container>
-      <h1>You have no domains</h1>
-    </Container>;
+  if (!ensNames || ensNames?.length === 0) {
+    return (
+      <Container>
+        <h1>You have no domains</h1>
+      </Container>
+    );
   }
 
   return (


### PR DESCRIPTION
# Summary

Adds support for fetching ENS name. Also excludes invalid names such as `[hash].abc.eth` 

<img width="1148" alt="image" src="https://user-images.githubusercontent.com/1926216/197761367-2781a244-65df-4418-9dbd-35d68ea760c9.png">
