### PR TITLE
feat: single-step IPNS setup

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": ["next/babel"],
-  "plugins": [["styled-components", { "ssr": true }]]
+  "plugins": [["styled-components", { "ssr": true, "displayName": true }]]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "path-browserify": "^1.0.1",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
-        "react-frame-component": "^5.2.3",
+        "react-frame-component": "^5.2.6",
         "react-hook-form": "^7.30.0",
         "react-i18next": "^12.1.1",
         "react-router-dom": "^6.3.0",
@@ -29560,9 +29560,9 @@
       }
     },
     "node_modules/react-frame-component": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/react-frame-component/-/react-frame-component-5.2.5.tgz",
-      "integrity": "sha512-7PKQb/7r7o0fdKyHi47g09PfXcJf21BO+i6Z4h59KDaDu1nv6HIG+yLuPiLid0N6CAvmbHhHP8pdP+3WZuIIgg==",
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/react-frame-component/-/react-frame-component-5.2.6.tgz",
+      "integrity": "sha512-CwkEM5VSt6nFwZ1Op8hi3JB5rPseZlmnp5CGiismVTauE6S4Jsc4TNMlT0O7Cts4WgIC3ZBAQ2p1Mm9XgLbj+w==",
       "peerDependencies": {
         "prop-types": "^15.5.9",
         "react": ">= 16.3",
@@ -57935,9 +57935,9 @@
       }
     },
     "react-frame-component": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/react-frame-component/-/react-frame-component-5.2.5.tgz",
-      "integrity": "sha512-7PKQb/7r7o0fdKyHi47g09PfXcJf21BO+i6Z4h59KDaDu1nv6HIG+yLuPiLid0N6CAvmbHhHP8pdP+3WZuIIgg==",
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/react-frame-component/-/react-frame-component-5.2.6.tgz",
+      "integrity": "sha512-CwkEM5VSt6nFwZ1Op8hi3JB5rPseZlmnp5CGiismVTauE6S4Jsc4TNMlT0O7Cts4WgIC3ZBAQ2p1Mm9XgLbj+w==",
       "requires": {}
     },
     "react-hook-form": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "path-browserify": "^1.0.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-frame-component": "^5.2.3",
+    "react-frame-component": "^5.2.6",
     "react-hook-form": "^7.30.0",
     "react-i18next": "^12.1.1",
     "react-router-dom": "^6.3.0",

--- a/src/api/GraphQl/schemas/generated/lens.tsx
+++ b/src/api/GraphQl/schemas/generated/lens.tsx
@@ -104,15 +104,6 @@ export type AccessConditionOutput = {
   token?: Maybe<Erc20OwnershipOutput>;
 };
 
-export type AchRequest = {
-  ethereumAddress: Scalars['EthereumAddress'];
-  freeTextHandle?: InputMaybe<Scalars['Boolean']>;
-  handle?: InputMaybe<Scalars['CreateHandle']>;
-  overrideAlreadyClaimed: Scalars['Boolean'];
-  overrideTradeMark: Scalars['Boolean'];
-  secret: Scalars['String'];
-};
-
 /** The request object to add interests to a profile */
 export type AddProfileInterestsRequest = {
   /** The profile interest to add */
@@ -934,10 +925,6 @@ export type CreateUnfollowBroadcastItemResult = {
   typedData: CreateBurnEip712TypedData;
 };
 
-export type CurRequest = {
-  secret: Scalars['String'];
-};
-
 /** The custom filters types */
 export enum CustomFiltersTypes {
   Gardeners = 'GARDENERS'
@@ -1541,12 +1528,6 @@ export type HasTxHashBeenIndexedRequest = {
   txId?: InputMaybe<Scalars['TxId']>;
 };
 
-export type HelRequest = {
-  handle: Scalars['Handle'];
-  remove: Scalars['Boolean'];
-  secret: Scalars['String'];
-};
-
 export type HidePublicationRequest = {
   /** Publication id */
   publicationId: Scalars['InternalPublicationId'];
@@ -1863,7 +1844,6 @@ export type ModuleInfo = {
 
 export type Mutation = {
   __typename?: 'Mutation';
-  ach?: Maybe<Scalars['Void']>;
   /** Adds profile interests to the given profile */
   addProfileInterests?: Maybe<Scalars['Void']>;
   addReaction?: Maybe<Scalars['Void']>;
@@ -1890,7 +1870,6 @@ export type Mutation = {
   createSetProfileMetadataViaDispatcher: RelayResult;
   createToggleFollowTypedData: CreateToggleFollowBroadcastItemResult;
   createUnfollowTypedData: CreateUnfollowBroadcastItemResult;
-  hel?: Maybe<Scalars['Void']>;
   hidePublication?: Maybe<Scalars['Void']>;
   idKitPhoneVerifyWebhook: IdKitPhoneVerifyWebhookResultStatusType;
   proxyAction: Scalars['ProxyActionId'];
@@ -1899,11 +1878,6 @@ export type Mutation = {
   removeProfileInterests?: Maybe<Scalars['Void']>;
   removeReaction?: Maybe<Scalars['Void']>;
   reportPublication?: Maybe<Scalars['Void']>;
-};
-
-
-export type MutationAchArgs = {
-  request: AchRequest;
 };
 
 
@@ -2043,11 +2017,6 @@ export type MutationCreateToggleFollowTypedDataArgs = {
 export type MutationCreateUnfollowTypedDataArgs = {
   options?: InputMaybe<TypedDataOptions>;
   request: UnfollowRequest;
-};
-
-
-export type MutationHelArgs = {
-  request: HelRequest;
 };
 
 
@@ -3089,7 +3058,6 @@ export type Query = {
   challenge: AuthChallengeResult;
   claimableHandles: ClaimableHandles;
   claimableStatus: ClaimStatus;
-  cur: Array<Scalars['String']>;
   defaultProfile?: Maybe<Profile>;
   doesFollow: Array<DoesFollowResponse>;
   enabledModuleCurrencies: Array<Erc20>;
@@ -3127,7 +3095,6 @@ export type Query = {
   publicationRevenue?: Maybe<PublicationRevenue>;
   publications: PaginatedPublicationResult;
   recommendedProfiles: Array<Profile>;
-  rel?: Maybe<Scalars['Void']>;
   search: SearchResult;
   /** @deprecated You should be using feed, this will not be supported after 15th November 2021, please migrate. */
   timeline: PaginatedTimelineResult;
@@ -3153,11 +3120,6 @@ export type QueryApprovedModuleAllowanceAmountArgs = {
 
 export type QueryChallengeArgs = {
   request: ChallengeRequest;
-};
-
-
-export type QueryCurArgs = {
-  request: CurRequest;
 };
 
 
@@ -3316,11 +3278,6 @@ export type QueryRecommendedProfilesArgs = {
 };
 
 
-export type QueryRelArgs = {
-  request: RelRequest;
-};
-
-
 export type QuerySearchArgs = {
   request: SearchQueryRequest;
 };
@@ -3411,11 +3368,6 @@ export enum ReferenceModules {
 export type RefreshRequest = {
   /** The refresh token */
   refreshToken: Scalars['Jwt'];
-};
-
-export type RelRequest = {
-  ethereumAddress: Scalars['EthereumAddress'];
-  secret: Scalars['String'];
 };
 
 export type RelayError = {

--- a/src/api/RestAPI/hooks/useDeployedPageData.ts
+++ b/src/api/RestAPI/hooks/useDeployedPageData.ts
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useRainbow } from '../../../hooks/useRainbow';
 import { nimiClient } from '../utils';
 
-interface DeployedNimiPageType {
+interface NimiSnapshot {
   publisher: string;
   cid: string | null;
   cidV1: string | null;
@@ -22,18 +22,22 @@ export function useDeployedPageData(ensName: string) {
   const { chainId } = useRainbow();
 
   const getDeployedPageData = async () => {
-    const params = {
-      ens: ensName,
-    };
-
-    const { data } = await nimiClient.get<{ data: DeployedNimiPageType[] }>(`/nimi/by`, { params });
+    const { data } = await nimiClient.get<{
+      data: {
+        ipns?: string;
+        nimi?: NimiSnapshot;
+      };
+    }>(`/ens/has-nimi-ipns`, {
+      params: {
+        domain: ensName,
+      },
+    });
     return data;
   };
 
   return useQuery(['fetchDeployedNimiData', ensName, chainId], getDeployedPageData, {
     select: ({ data }) => {
-      if (data.length) return data[0];
-      else return undefined;
+      return data;
     },
   });
 }

--- a/src/api/RestAPI/hooks/usePoapsFromUser.ts
+++ b/src/api/RestAPI/hooks/usePoapsFromUser.ts
@@ -1,29 +1,12 @@
+import { POAPToken } from '@nimi.io/card/types';
 import { useQuery } from '@tanstack/react-query';
 
 import { getPOAPAPIClient } from '../utils';
 
-type Poap = {
-  city: string;
-  country: string;
-  desciption: string;
-  end_date: string;
-  event_url?: string;
-  expiry_date: string;
-  fancy_id: string;
-  id: number;
-  image_url: string;
-  name: string;
-  start_date: string;
-  supply: number;
-  year: number;
-};
-
-export interface PoapData {
-  chain: string;
-  created: string;
-  event: Poap;
-  owner: string;
-  tokenId: string;
+export async function fetchUserPOAPs(account: string) {
+  const poapClient = getPOAPAPIClient();
+  const { data } = await poapClient.get<POAPToken[]>(`/actions/scan/${account.toLowerCase()}`);
+  return data;
 }
 
 /**
@@ -31,12 +14,8 @@ export interface PoapData {
  */
 export function usePoapsFromUser(account?: string) {
   const getPoapsFromUser = async () => {
-    if (!account) {
-      return [];
-    }
-    const poapClient = getPOAPAPIClient();
-    const { data } = await poapClient.get<PoapData[]>(`/actions/scan/${account.toLowerCase()}`);
-    return data;
+    if (!account) return [];
+    return fetchUserPOAPs(account);
   };
 
   return useQuery(['fetchUserPoaps', account], getPoapsFromUser);

--- a/src/api/RestAPI/hooks/usePublishNimiIPNS.ts
+++ b/src/api/RestAPI/hooks/usePublishNimiIPNS.ts
@@ -13,7 +13,7 @@ type UpdateNimiViaIPNSParams = PublishNimiViaIPNSParams & {
 };
 
 interface PublishNimiIPNSResponse {
-  cidV1: string;
+  cid: string;
   ipns: string;
 }
 

--- a/src/api/RestAPI/hooks/usePublishNimiIPNS.ts
+++ b/src/api/RestAPI/hooks/usePublishNimiIPNS.ts
@@ -3,11 +3,14 @@ import { useMutation } from '@tanstack/react-query';
 
 import { nimiClient } from '../utils';
 
-interface PublishNimiViaIPNSParams {
+export interface PublishNimiViaIPNSParams {
   chainId: number;
   nimi: Nimi;
-  signature: string;
 }
+
+type UpdateNimiViaIPNSParams = PublishNimiViaIPNSParams & {
+  signature: string;
+};
 
 interface PublishNimiIPNSResponse {
   cidV1: string;
@@ -21,9 +24,23 @@ const postUserData = async (params: PublishNimiViaIPNSParams) => {
   return data.data;
 };
 
+const updateNimiIPNS = async (params: UpdateNimiViaIPNSParams) => {
+  const { data } = await nimiClient.put<{
+    data: PublishNimiIPNSResponse;
+  }>('/nimi/publish/ipns', params);
+  return data.data;
+};
+
 /**
  * Returns mutation for getting IPNS hash
  */
 export function usePublishNimiIPNS() {
   return useMutation(['publishNimiIPNS'], postUserData);
+}
+
+/**
+ * Returns mutation for getting IPNS hash
+ */
+export function useUpdateNimiIPNS() {
+  return useMutation(['updateNimiIPNS'], updateNimiIPNS);
 }

--- a/src/components/CreateNimi/CreateNimi.tsx
+++ b/src/components/CreateNimi/CreateNimi.tsx
@@ -22,7 +22,7 @@ import { useSignMessage } from 'wagmi';
 
 import { usePublishNimiIPNS, useUpdateNimiIPNS } from '../../api/RestAPI/hooks/usePublishNimiIPNS';
 import { useUploadImageToIPFS } from '../../api/RestAPI/hooks/useUploadImageToIPFS';
-import PlaceholderMini from '../../assets/images/nimi-placeholder.png';
+import nimiPlaceholderImage from '../../assets/images/nimi-placeholder.png';
 // Partials
 import { supportedImageTypes } from '../../constants';
 import { useENSPublicResolverContract } from '../../hooks/useENSPublicResolverContract';
@@ -78,13 +78,7 @@ import { themes } from './themes';
 export interface CreateNimiProps {
   ensAddress: string;
   ensName: string;
-  /**
-   * Available themes for the user to choose from
-   */
   availableThemes: NimiCuratedTheme[];
-  /**
-   * The initial Nimi to edit
-   */
   initialNimi: Nimi;
   nimiIPNSKey?: string;
 }
@@ -188,7 +182,7 @@ export function CreateNimi({ ensAddress, ensName, availableThemes, initialNimi, 
           chainId: 1, // always mainnet
           signature,
         });
-        if (!updateNimiResponse || !updateNimiResponse.cidV1) {
+        if (!updateNimiResponse || !updateNimiResponse.cid) {
           throw new Error('No response from updateNimiAsync');
         }
 
@@ -198,12 +192,12 @@ export function CreateNimi({ ensAddress, ensName, availableThemes, initialNimi, 
       }
 
       // Publishing a new Nimi IPNS record
-      const { cidV1, ipns } = await publishNimiAsync({
+      const { cid, ipns } = await publishNimiAsync({
         nimi,
-        chainId: 1, // always mainnet
+        chainId: chainId as number,
       });
 
-      if (!cidV1) {
+      if (!cid) {
         throw new Error('No CID returned from publishNimiViaIPNS');
       }
 
@@ -222,7 +216,7 @@ export function CreateNimi({ ensAddress, ensName, availableThemes, initialNimi, 
       }
 
       // Set the content
-      setPublishNimiResponseIpfsHash(cidV1);
+      setPublishNimiResponseIpfsHash(cid);
       const setContentHashTransaction = await setENSNameContentHash({
         contract: publicResolverContract,
         name: nimi.ensName,
@@ -336,7 +330,11 @@ export function CreateNimi({ ensAddress, ensName, availableThemes, initialNimi, 
                   <Toplabel>Profile Picture</Toplabel>
                   <ProfileImage
                     src={
-                      customImg ? customImg : formWatchPayload.image?.url ? formWatchPayload.image.url : PlaceholderMini
+                      customImg
+                        ? customImg
+                        : formWatchPayload.image?.url
+                        ? formWatchPayload.image.url
+                        : nimiPlaceholderImage.src
                     }
                   />
                   {imgErrorMessage && <ErrorMessage>{imgErrorMessage}</ErrorMessage>}
@@ -565,10 +563,10 @@ export function CreateNimi({ ensAddress, ensName, availableThemes, initialNimi, 
             if (nftAsset) {
               setValue('image', {
                 type: NimiImageType.ERC721,
-                contract: nftAsset.assetContract.address,
-                tokenId: nftAsset.tokenId as any,
-                tokenUri: nftAsset.externalLink,
-                url: nftAsset.imageUrl,
+                contract: nftAsset.asset_contract.address,
+                tokenId: nftAsset.token_id as any,
+                tokenUri: nftAsset.external_link,
+                url: nftAsset.image_url,
               });
             }
 

--- a/src/components/CreateNimi/CreateNimiContainer.tsx
+++ b/src/components/CreateNimi/CreateNimiContainer.tsx
@@ -17,7 +17,11 @@ export function CreateNimiContainer({ ensName }: CreateNimiContainerProps) {
   const { avaliableThemes, isLoading: isThemeLoading, hasPoaps } = useAvaliableThemesFromPoaps(account);
 
   //check for users current Nimi profile data or else adds data generated from ens
-  const { data: initialNimi, loading: initialNimiLoading } = useInitialtNimiData({
+  const {
+    data: initialNimi,
+    loading: initialNimiLoading,
+    ipns,
+  } = useInitialtNimiData({
     ensName,
     account,
   });
@@ -33,6 +37,7 @@ export function CreateNimiContainer({ ensName }: CreateNimiContainerProps) {
         ensName={ensName as string}
         availableThemes={avaliableThemes}
         initialNimi={insertPoapWidgetIntoNimi(initialNimi, hasPoaps, account)}
+        nimiIPNSKey={ipns}
       />
     </Container>
   );

--- a/src/hooks/useAvaliableThemesFromPoaps.ts
+++ b/src/hooks/useAvaliableThemesFromPoaps.ts
@@ -1,7 +1,7 @@
-import { NimiThemeType } from '@nimi.io/card/types';
+import { NimiThemeType, POAPToken } from '@nimi.io/card/types';
 import createDebugger from 'debug';
 
-import { PoapData, usePoapsFromUser } from '../api/RestAPI/hooks/usePoapsFromUser';
+import { usePoapsFromUser } from '../api/RestAPI/hooks/usePoapsFromUser';
 import { NimiCuratedTheme } from '../types';
 
 export interface UseAvaliableTheme {
@@ -17,6 +17,26 @@ const themeToPoapMapping: { theme: NimiCuratedTheme; eventId: number[] }[] = [
   { theme: NimiThemeType.DAIVINITY, eventId: [74051] },
 ];
 
+/**
+ * Returns array of themes user has available available Themes
+ * @param userPOAPList
+ * @returns
+ */
+export function getAvailableThemesByPOAPs(userPOAPList?: POAPToken[]) {
+  const themes: NimiCuratedTheme[] = [NimiThemeType.NIMI];
+
+  if (!userPOAPList) return themes;
+
+  for (const theme of themeToPoapMapping) {
+    const hasTheme = userPOAPList.some((poap) => theme.eventId.includes(poap.event.id));
+    if (hasTheme) {
+      themes.push(theme.theme);
+    }
+  }
+
+  return themes;
+}
+
 const debug = createDebugger('hooks:useAvaliableThemesFromPoaps');
 
 /**
@@ -25,25 +45,11 @@ const debug = createDebugger('hooks:useAvaliableThemesFromPoaps');
 export function useAvaliableThemesFromPoaps(account?: string): UseAvaliableTheme {
   const { data, isLoading, isFetching } = usePoapsFromUser(account);
 
-  function getAvaliableThemes(userPOAPList?: PoapData[]) {
-    const themes: NimiCuratedTheme[] = [NimiThemeType.NIMI];
-
-    if (userPOAPList) {
-      for (const theme of themeToPoapMapping) {
-        const hasTheme = userPOAPList.some((poap) => theme.eventId.includes(poap.event.id));
-        if (hasTheme) {
-          themes.push(theme.theme);
-        }
-      }
-    }
-
-    return themes;
-  }
   debug({ poapData: data });
 
   return {
     isLoading: isLoading || isFetching,
-    avaliableThemes: getAvaliableThemes(data),
+    avaliableThemes: getAvailableThemesByPOAPs(data),
     hasPoaps: data ? data.length !== 0 : false,
   };
 }

--- a/src/hooks/useDefaultNimiData.ts
+++ b/src/hooks/useDefaultNimiData.ts
@@ -68,7 +68,7 @@ export function useInitialtNimiData({ ensName, account }: InitialNimiDataProps):
     ensName,
   ]);
 
-  debug({ NimiObject: nimiObject });
+  debug({ nimiObject });
 
   return {
     loading: isDepoyedLoading || isGeneratedFetching,

--- a/src/hooks/useDefaultNimiData.ts
+++ b/src/hooks/useDefaultNimiData.ts
@@ -9,6 +9,7 @@ const debug = createDebugger('hooks:useDefaultNimiData');
 
 interface UseInitialNimiData {
   data?: Nimi;
+  ipns?: string;
   loading: boolean;
 }
 interface InitialNimiDataProps {
@@ -45,8 +46,11 @@ export function useInitialtNimiData({ ensName, account }: InitialNimiDataProps):
       widgets: [],
     };
 
-    if (isDeployedSuccess && deployedNimi && !isDepoyedLoading) nimi = deployedNimi.nimi;
-    else if (isGeneratedSuccess && generatedNimi && !isGeneratedFetching) nimi = generatedNimi;
+    if (isDeployedSuccess && deployedNimi.nimi && !isDepoyedLoading) {
+      nimi = deployedNimi.nimi.nimi;
+    } else if (isGeneratedSuccess && generatedNimi && !isGeneratedFetching) {
+      nimi = generatedNimi;
+    }
 
     if (!(isDepoyedLoading || isGeneratedFetching)) {
       if (!nimi.theme) nimi.theme = defaultTheme;
@@ -69,5 +73,6 @@ export function useInitialtNimiData({ ensName, account }: InitialNimiDataProps):
   return {
     loading: isDepoyedLoading || isGeneratedFetching,
     data: nimiObject,
+    ipns: deployedNimi?.ipns,
   };
 }

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -17,7 +17,6 @@ export const resources = {
 
 use(initReactI18next).init({
   lng: 'en',
-  debug: true,
   resources,
   defaultNS,
 });

--- a/src/layout/AppWrapper.tsx
+++ b/src/layout/AppWrapper.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
@@ -12,23 +12,26 @@ import { FOOTER_HEIGHT, HEADER_HEIGHT, MEDIA_WIDTHS } from '../theme';
 export function PageLayout({ children }: PropsWithChildren) {
   const { chainId } = useRainbow();
   const { t } = useTranslation(['common', 'landing']);
+  const [isNetworkSupported, setIsNetworkSupported] = useState(false);
+
+  useEffect(() => {
+    setIsNetworkSupported(ENV_SUPPORTED_CHAIN_IDS.includes(chainId as number));
+  }, [chainId]);
 
   return (
     <Container>
       <Header />
       <Content>
-        {(() => {
-          if (!ENV_SUPPORTED_CHAIN_IDS.includes(chainId as number))
-            return (
-              <ErrorContainer>
-                <Heading>{t('error.unsupportedNetwork')}</Heading>
-                <Heading type="sub" color="#000">
-                  Please change your network by clicking the account button on the top right.
-                </Heading>
-              </ErrorContainer>
-            );
-          return children;
-        })()}
+        {isNetworkSupported ? (
+          children
+        ) : (
+          <ErrorContainer>
+            <Heading>{t('error.unsupportedNetwork')}</Heading>
+            <Heading type="sub" color="#000">
+              Please change your network by clicking the account button on the top right.
+            </Heading>
+          </ErrorContainer>
+        )}
       </Content>
       <Footer />
     </Container>

--- a/src/pages/domains/[domain]/index.tsx
+++ b/src/pages/domains/[domain]/index.tsx
@@ -1,26 +1,148 @@
+import { Nimi, POAPToken } from '@nimi.io/card/types';
+import { GetServerSidePropsContext } from 'next';
 import Head from 'next/head';
-import { useRouter } from 'next/router';
 
-import { CreateNimiContainer } from '../../../components/CreateNimi/CreateNimiContainer';
+import { fetchUserPOAPs } from '../../../api/RestAPI/hooks/usePoapsFromUser';
+import { nimiClient } from '../../../api/RestAPI/utils';
+import { Container } from '../../../components/Container';
+import { CreateNimi } from '../../../components/CreateNimi';
+import { getAvailableThemesByPOAPs } from '../../../hooks/useAvaliableThemesFromPoaps';
 import { PageLayout } from '../../../layout';
+import { insertPoapWidgetIntoNimi } from '../../../utils';
 
-export default function CreateNimiPage() {
-  const router = useRouter();
-  const { domain } = router.query;
+interface NimiSnapshot {
+  publisher: string;
+  cid: string | null;
+  nimi: Nimi;
+  createdAt: string;
+  updatedAt: string;
+  id: string;
+}
 
-  // DOn't render anything on server side
-  if (typeof window === 'undefined') {
-    console.log('Server side rendering');
-    return null;
+export async function fetchNimiIPNS(ensName: string) {
+  const url = `http://127.0.0.1:4002/ens/has-nimi-ipns?domain=${ensName}`;
+
+  const rawResponse = await fetch(url, {
+    method: 'GET',
+  }).then();
+
+  if (!rawResponse.ok) {
+    throw new Error('Network response was not ok');
   }
 
+  const data = (await rawResponse.json()) as {
+    data: {
+      ipns?: string;
+      nimi?: NimiSnapshot;
+    };
+  };
+
+  return data.data;
+}
+
+export async function generateNimiFromENS(ensName: string) {
+  const { data } = await nimiClient.get<{
+    data: {
+      nimi: Nimi;
+    };
+  }>(`/nimi/generate`, {
+    params: {
+      domain: ensName,
+    },
+  });
+
+  return data.data;
+}
+
+interface CreateNimiPageProps {
+  availableThemes: ReturnType<typeof getAvailableThemesByPOAPs>;
+  domain: string;
+  ipnsKey?: string;
+  nimiSnapshot?: NimiSnapshot;
+  initialNimi: Nimi;
+  poapList: POAPToken[];
+}
+
+// This is the page that will be server side rendered
+export async function getServerSideProps(
+  context: GetServerSidePropsContext<{
+    domain: string;
+  }>
+): Promise<{
+  props: CreateNimiPageProps;
+}> {
+  let props = {
+    availableThemes: [],
+    domain: context?.params?.domain,
+    initialNimi: {} as Nimi,
+    poapList: [],
+  } as CreateNimiPageProps;
+
+  try {
+    if (!context?.params?.domain || context?.params?.domain === '[object Object]') {
+      throw new Error('No domain provided');
+    }
+
+    const domain = context.params.domain;
+    // Nimi Snapshot from the API
+    const nimiIPNSSnapshot = await fetchNimiIPNS(domain);
+    // If the user has a Nimi IPNS, redirect to the Nimi page
+    if (nimiIPNSSnapshot.ipns && nimiIPNSSnapshot.nimi) {
+      props = {
+        ...props,
+        ipnsKey: nimiIPNSSnapshot.ipns,
+        nimiSnapshot: nimiIPNSSnapshot.nimi,
+        initialNimi: nimiIPNSSnapshot.nimi.nimi,
+      };
+    } else {
+      const { nimi } = await generateNimiFromENS(domain);
+      props['initialNimi'] = nimi;
+    }
+
+    if (!props.initialNimi) {
+      throw new Error('No Nimi found');
+    }
+
+    // Attempt to load
+    const poapList = await fetchUserPOAPs(props.initialNimi.ensAddress as string);
+    const availableThemes = getAvailableThemesByPOAPs(poapList);
+
+    if (poapList) {
+      props = {
+        ...props,
+        poapList,
+        availableThemes,
+      };
+    }
+  } catch (e) {
+    console.log(e);
+  }
+  // If the user doesn't have a Nimi IPNS, generate a Nimi from the ENS name
+  return { props };
+}
+
+export default function CreateNimiPage({
+  domain,
+  ipnsKey,
+  initialNimi,
+  poapList,
+  availableThemes,
+}: Awaited<ReturnType<typeof getServerSideProps>>['props']) {
   return (
     <>
       <Head>
         <title>Create Nimi for {domain}</title>
       </Head>
       <PageLayout>
-        <CreateNimiContainer ensName={domain as string} />
+        <Container>
+          <CreateNimi
+            ensAddress={initialNimi?.ensAddress as string}
+            ensName={domain}
+            availableThemes={availableThemes}
+            initialNimi={insertPoapWidgetIntoNimi(initialNimi, poapList.length > 0, initialNimi?.ensAddress)}
+            nimiIPNSKey={ipnsKey}
+          />
+        </Container>
       </PageLayout>
     </>
   );


### PR DESCRIPTION
# Summary

**Breaking changes**. This requires using of the [Nimi API v2.0](https://api-dev.nimi.io/v2.0/docs/).

The single setup works by creating a temporary IPNS record. Then, convert it to a permanent record once the user submits the on-chain IPNS record as their ENS name's `contentHash`. 

This works because only the owner and controller can update the ENS names, there's no need to verify the IPNS record ownership using signatures.

Besides addressing #236, this PR includes some fixes to the next.js hydration problems reported by @bejzik8. 
